### PR TITLE
Update serializer.py

### DIFF
--- a/zproc/serializer.py
+++ b/zproc/serializer.py
@@ -1,7 +1,7 @@
 import pickle
 from typing import Callable, Any, Dict
 
-from cloudpickle import cloudpickle
+import cloudpickle
 
 from zproc import exceptions
 


### PR DESCRIPTION
Fix AttributeError: module 'cloudpickle.cloudpickle' has no attribute 'dumps' while running Oscilloscope package.